### PR TITLE
use correct payload length

### DIFF
--- a/main.js
+++ b/main.js
@@ -139,7 +139,7 @@ function notifySlack(payload) {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
-            "Content-Length": payload.length,
+            "Content-Length": Buffer.byteLength(payload, 'utf8'),
         },
         agent: new https.Agent({ keepAlive: false }),
     };

--- a/main.js
+++ b/main.js
@@ -155,11 +155,13 @@ function notifySlack(payload) {
             if (resp.statusCode === 200) {
                 console.log("Sent message to Slack OK");
             } else {
+                console.error("Payload:", payload);
                 throw Error(`Failed to post to Slack! statusCode = ${resp.statusCode}`);
             }
         });
     }).on("error", (err) => {
-        console.log("Error making request to Slack:", err);
+        console.error("Payload:", payload);
+        console.error("Error making request to Slack:", err);
         throw Error("Failed to make request to Slack");
     });
     req.write(payload);


### PR DESCRIPTION
We use this action on the media CI, and we appear to have errors when a utf8 character is included in the message. Specifically we use author names on the message, and as some names in Norwegian are utf8 encoded the action failed to post the request to slack. The error was pretty poor as we just get "invalid payload."

Example of a failure here: https://github.com/pexip/media/actions/runs/15014016323/job/42200149742

It turns out this was due to how we compute the length of the payload. By the time we post the request the JSON blob is already a string, so its payload should be computed in terms of a utf8 encoding rather than simply the length on the js object holding it.